### PR TITLE
bottom bar navigator and its history implement

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -70,9 +70,7 @@ class App extends GetView<BottomNavController> {
         ),
       ),
       ), 
-      onWillPop: ()async{
-        return false;//앱이 닫힐건지 열릴건지 bool값으로 결정
-      },
+      onWillPop: controller.willPopAction
     );
   }
 }

--- a/lib/src/controller/bottom_nav_controller.dart
+++ b/lib/src/controller/bottom_nav_controller.dart
@@ -2,20 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_sns_form/src/pages/upload.dart';
 import 'package:get/get.dart';
 
+
 class BottomNavController extends GetxController{
   RxInt pageIndex = 0.obs;
 
+  List<int> bottomHistory =[0];
 
-
-  void changeBottomNav(int value) {
+  void changeBottomNav(int value,{bool hasGesture = true}) {
     
     if(value ==0){
       //home event
-      _changePage(value);
+      _changePage(value, hasGesture: hasGesture);
     }
     if(value ==1){
       //search event
-      _changePage(value);
+      _changePage(value, hasGesture: hasGesture);
     }
     if(value ==2){
       //upload event
@@ -23,15 +24,39 @@ class BottomNavController extends GetxController{
     }
     if(value ==3){
       //activity event
-      _changePage(value);
+      _changePage(value, hasGesture: hasGesture);
     }
     if(value ==4){
       //mypage event
-      _changePage(value);
+      _changePage(value, hasGesture: hasGesture);
     }
   }
   //upload제외새로운 페이지가 떠야행!
-  void _changePage(int value){
+  void _changePage(int value,{bool hasGesture = true}){
       pageIndex(value);
+      if (hasGesture ==false) return;
+      if (bottomHistory.contains(value)){
+        bottomHistory.remove(value);
+      }
+      bottomHistory.add(value);
+      print(bottomHistory);
   }
+
+  Future<bool> willPopAction() async{
+    if (bottomHistory.length == 1){
+      //showDiaglog(context: Get.context,builder:(context)=>MessagePopup())
+      print('exit');
+      return Future<bool>.value(true);
+    }
+    else{
+      //bottomHistory.removeLast();
+      bottomHistory.removeAt(bottomHistory.length -1);
+      var index =bottomHistory.last;
+      changeBottomNav(index,hasGesture: false);
+      print('goto before page');
+      print(bottomHistory);
+      return Future<bool>.value(false);
+    }
+  }
+
 }


### PR DESCRIPTION
아래의 메뉴바를 눌렀을때 어느 메뉴를 눌렀는지 history를 리스트에 저장하고 뒤로가기버튼을 누르면 전페이지로 돌아가게끔 구현. 히스토리는 최대 4개만 쌓이게 하고 중복될 경우 리스트의 가장 끝부분으로 update됨.